### PR TITLE
Disable method length

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,8 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 LineLength:
   Max: 120
+MethodLength:
+  Enabled: false
 Style/EmptyMethod:
   Enabled: false
 Bundler/OrderedGems:


### PR DESCRIPTION
Stop rubocop nagging about method length for all users except James Thorp